### PR TITLE
update jackson-databind version (2.9.9.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.9.2</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Updated jackson-databind to verion 2.9.9.2 for security reasons.

Details:
https://nvd.nist.gov/vuln/detail/CVE-2019-14379
https://github.com/FasterXML/jackson-databind/issues/2387
