### PR TITLE
Atualização para versão 1.1.0 e adição da opção BS2_TRANSFER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ buildNumber.properties
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
+.classpath
+.factorypath
+.project
+.settings/org.eclipse.jdt.apt.core.prefs
+.settings/org.eclipse.jdt.core.prefs
+.settings/org.eclipse.m2e.core.prefs

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ buildNumber.properties
 .settings/org.eclipse.jdt.apt.core.prefs
 .settings/org.eclipse.jdt.core.prefs
 .settings/org.eclipse.m2e.core.prefs
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ buildNumber.properties
 .settings/org.eclipse.jdt.core.prefs
 .settings/org.eclipse.m2e.core.prefs
 .vscode/settings.json
+.vscode/*

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>br.com.paymee</groupId>
     <artifactId>paymee-java</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <build>

--- a/src/main/java/br/com/paymee/models/checkout/request/enums/PaymentMethod.java
+++ b/src/main/java/br/com/paymee/models/checkout/request/enums/PaymentMethod.java
@@ -11,5 +11,6 @@ public enum PaymentMethod {
     SANTANDER_DI,
     CEF_TRANSFER,
     ORIGINAL_TRANSFER,
-    INTER_TRANSFER;
+    INTER_TRANSFER,
+    BS2_TRANSFER;
 }


### PR DESCRIPTION
Uma vez que o projeto está na vesão 1.1.0 acho correto atualizar também a versão no pom.xml, pois quando formos empacotar o projeto no como .jar a versão correta será utilizada para criar o nome do arquivo.